### PR TITLE
Update docker image (and the nix version in there)

### DIFF
--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN wget -O- http://nixos.org/releases/nix/nix-1.11.7/nix-1.11.7-x86_64-linux.tar.bz2 | bzcat - | tar xf - \
+RUN wget -O- http://nixos.org/releases/nix/nix-1.11.10/nix-1.11.10-x86_64-linux.tar.bz2 | bzcat - | tar xf - \
     && echo "nixbld:x:30000:nixbld1,nixbld2,nixbld3,nixbld4,nixbld5,nixbld6,nixbld7,nixbld8,nixbld9,nixbld10,nixbld11,nixbld12,nixbld13,nixbld14,nixbld15,nixbld16,nixbld17,nixbld18,nixbld19,nixbld20,nixbld21,nixbld22,nixbld23,nixbld24,nixbld25,nixbld26,nixbld27,nixbld28,nixbld29,nixbld30" >> /etc/group \
     && for i in $(seq 1 30); do echo "nixbld$i:x:$((30000 + $i)):30000:::" >> /etc/passwd; done \
     && mkdir -m 0755 /nix && USER=root sh nix-*-x86_64-linux/install \


### PR DESCRIPTION
There seems to be a problem with the SSL from alpine, so maybe we can have a new docker image on hub.docker.com?

See https://hub.docker.com/r/nixos/nix/ -> comment by pierrebeaucamp

Might as well update nix while we're at it.
(I have no idea who can update the docker image)